### PR TITLE
Fix up some log levels

### DIFF
--- a/e2b_mcp/runner.py
+++ b/e2b_mcp/runner.py
@@ -59,7 +59,7 @@ class E2BMCPRunner:
             config: Server configuration
         """
         self.server_configs[config.name] = config
-        logger.info(f"Added MCP server config: {config.name}")
+        logger.debug(f"Added MCP server config: {config.name}")
 
     def add_server_from_dict(self, name: str, config_data: dict[str, Any]) -> None:
         """
@@ -94,7 +94,7 @@ class E2BMCPRunner:
 
         for name, config in validated_configs.items():
             self.server_configs[name] = config
-            logger.info(f"Added MCP server config: {name}")
+            logger.debug(f"Added MCP server config: {name}")
 
     def list_servers(self) -> list[str]:
         """List all configured server names."""
@@ -179,7 +179,7 @@ class E2BMCPRunner:
         try:
             # Create E2B sandbox (async)
             sandbox = await Sandbox.create(api_key=self.api_key)
-            logger.info(f"Created sandbox {sandbox.sandbox_id}")
+            logger.debug(f"Created sandbox {sandbox.sandbox_id}")
 
             # Set timeout
             await sandbox.set_timeout(config.timeout_minutes * 60)
@@ -231,7 +231,7 @@ class E2BMCPRunner:
                 # Convert to Tool objects
                 tools = [Tool.from_mcp_tool(tool_data, server_name) for tool_data in tools_data]
 
-                logger.info(f"Discovered {len(tools)} tools from {server_name}")
+                logger.debug(f"Discovered {len(tools)} tools from {server_name}")
                 return tools
 
             except Exception as e:
@@ -365,7 +365,7 @@ class E2BMCPRunner:
             # Cache tools in session
             session.tools = tools
 
-            logger.info(f"Discovered {len(tools)} tools from {session.server_name}")
+            logger.debug(f"Discovered {len(tools)} tools from {session.server_name}")
             return tools
 
         except Exception as e:
@@ -405,7 +405,7 @@ class E2BMCPRunner:
 
         # Install package if specified
         if config.package:
-            logger.info(f"Installing package: {config.package}")
+            logger.debug(f"Installing package: {config.package}")
             # Security: properly escape package name to prevent injection
             shlex.quote(config.package)
             install_code = f"""
@@ -431,7 +431,7 @@ print("Package installed successfully")
 
             env_code = "; ".join(env_commands)
             await sandbox.run_code(env_code)
-            logger.info(f"Set environment variables: {list(config.env.keys())}")
+            logger.debug(f"Set environment variables: {list(config.env.keys())}")
 
         # Extract file path from command
         cmd_parts = config.command.split()
@@ -448,7 +448,7 @@ print("Package installed successfully")
         # Some use stdio by default, some need --stdio flag, some use other conventions
         command = config.command
 
-        logger.info(f"Starting MCP server with command: {command}")
+        logger.debug(f"Starting MCP server with command: {command}")
         try:
             logger.debug(f"Executing command: {command}")
 
@@ -510,7 +510,7 @@ all_python = [line for line in lines if 'python' in line and 'test_mcp_server.py
 print(f"All MCP processes: {all_python}")
 """
                 )
-                logger.info(f"Process check result: {getattr(ps_result, 'stdout', '')}")
+                logger.debug(f"Process check result: {getattr(ps_result, 'stdout', '')}")
             except Exception as e:
                 logger.debug(f"Failed to check processes: {e}")
 
@@ -518,7 +518,7 @@ print(f"All MCP processes: {all_python}")
             await self._wait_for_server_ready(session, sandbox)
 
             session.initialized = True
-            logger.info(f"MCP server started successfully in session {session.session_id}")
+            logger.debug(f"MCP server started successfully in session {session.session_id}")
 
         except Exception as e:
             logger.error(f"Failed to start MCP server: {e}")
@@ -713,7 +713,7 @@ print("=== END DEBUG ===")
 
             # Close sandbox
             await sandbox.kill()
-            logger.info(f"Cleaned up session {session.session_id}")
+            logger.debug(f"Cleaned up session {session.session_id}")
 
         except Exception as e:
             logger.warning(f"Error during session cleanup: {e}")


### PR DESCRIPTION
This pull request updates the logging level for various operations in the `e2b_mcp/runner.py` file, changing them from `info` to `debug`. These changes aim to reduce the verbosity of the logs during normal operation while retaining detailed logs for debugging purposes.

### Logging Level Adjustments:

* Changed the logging level to `debug` for adding server configurations in the `add_server` and `add_servers` methods. [[1]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L62-R62) [[2]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L97-R97)
* Updated the logging level to `debug` for sandbox creation and tool discovery in the `create_session`, `discover_tools`, and `_discover_tools_for_session` methods. [[1]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L182-R182) [[2]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L234-R234) [[3]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L368-R368)
* Adjusted the logging level to `debug` for MCP server setup operations, including package installation, environment variable configuration, and server startup in the `_setup_mcp_server` method. [[1]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L408-R408) [[2]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L434-R434) [[3]](diffhunk://#diff-563afff091954f90e3712cd6a34a93c4193080366038461a4ef52c486074d763L451-R451)
* Set the logging level to `debug` for process checks and server initialization in the `_on_stderr` method.
* Changed the logging level to `debug` for session cleanup operations in the `_cleanup_session` method.